### PR TITLE
Add reservamos funnel URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
           "https://viajes.intramobility.com.mx/version",
           "https://viagens.saritur.com.br/version",
           "https://viagens.gontijo.com.br/version",
+          "https://viaje.reservamos.mx/version",
         ],
       },
       {
@@ -64,6 +65,7 @@
           "https://gfa-staging.resertravel.com/version",
           "https://roll-bits-sbx.resertravel.com/version",
           "https://cds-sbx.resertravel.com/version",
+          "https://reservamos-sbx.resertravel.com/version",
         ],
       },
     ];


### PR DESCRIPTION
## Summary
- Add `https://viaje.reservamos.mx/version` to the production funnels list
- Add `https://reservamos-sbx.resertravel.com/version` to the sandbox funnels list

## Test plan
- [x] Open the deploy status page and confirm both new entries appear and load their version info

🤖 Generated with [Claude Code](https://claude.com/claude-code)